### PR TITLE
Sort files, normalize and check postcodes, compare files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# typical data input or output files
+codepo_gb/
+NI-postcodes.csv
+*.csv
+*.zip
+*.gz
+__pycache__

--- a/README.md
+++ b/README.md
@@ -79,7 +79,20 @@ Creating the file
         # expect 13M
         ls -lah
 
-4. Cleanup source files
+4. Compare to previous data
+
+        ./compare.py gb_postcodes.previous.csv gb_postcodes.csv
+        Read 1717777 postcodes from old file gb_postcodes.previous.csv
+        Read 1719485 postcodes from new file gb_postcodes.csv
+        Added: 3674 (0.214%)
+        Deleted: 1966 (0.114%)
+        Position moved: 68857 (4.005%)
+        Position moved more than 100 meters: 10517 (0.612%)
+        Position moved more than 1000 meters: 553 (0.032%)
+        Position moved more than 10000 meters: 16 (0.001%)
+        Average distance difference of all updates: 83.76 meters
+
+5. Cleanup source files
 
         rm -r codepo_gb.zip codepo_gb NI-postcodes.csv
 

--- a/compare.py
+++ b/compare.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+
+import sys
+from csv import DictReader
+from lib.convert import haversine
+
+
+
+######################################################################
+## Open and read files
+##
+
+if len(sys.argv) != 3:
+    sys.exit('Expected two filenames')
+
+filename_old = sys.argv[1]
+filename_new = sys.argv[2]
+
+postcodes_old = {}
+postcodes_new = {}
+
+with open(filename_old) as file:
+    for row in DictReader(file):
+        postcodes_old[row['postcode']] = {'lat': float(row['lat']), 'lon': float(row['lon'])}
+
+with open(filename_new) as file:
+    for row in DictReader(file):
+        postcodes_new[row['postcode']] = {'lat': float(row['lat']), 'lon': float(row['lon'])}
+
+print('Read %d postcodes from old file %s' % (len(postcodes_old), filename_old))
+print('Read %d postcodes from new file %s' % (len(postcodes_new), filename_new))
+
+
+######################################################################
+## Compare files
+##
+
+num_added = 0
+num_moved = 0
+num_moved_100 = 0
+num_moved_1000 = 0
+num_moved_10000 = 0
+distance_differences = 0
+
+for postcode in postcodes_new:
+    if postcode in postcodes_old:
+        if (postcodes_new[postcode]['lat'] != postcodes_old[postcode]['lat']) or (postcodes_new[postcode]['lon'] != postcodes_old[postcode]['lon']):
+            num_moved += 1
+            distance = haversine(
+                (postcodes_old[postcode]['lat'], postcodes_old[postcode]['lon']),
+                (postcodes_new[postcode]['lat'], postcodes_new[postcode]['lon'])
+            )
+            distance_differences += distance
+            if distance > 100:
+                num_moved_100 += 1
+            if distance > 1000:
+                num_moved_1000 += 1
+            if distance > 10000:
+                num_moved_10000 += 1
+    else:
+        num_added += 1
+
+num_deleted = 0
+for postcode in postcodes_old:
+    if postcode not in postcodes_new:
+        num_deleted += 1
+
+
+
+######################################################################
+## Output
+##
+
+print('Added: %d (%.3f%%)' % (
+    num_added,
+    num_added / len(postcodes_new) * 100)
+)
+print('Deleted: %d (%.3f%%)' % (
+    num_deleted,
+    num_deleted / len(postcodes_new) * 100)
+)
+print('Position moved: %d (%.3f%%)' % (
+    num_moved,
+    num_moved / len(postcodes_new) * 100)
+)
+print('Position moved more than 100 meters: %d (%.3f%%)' % (
+    num_moved_100,
+    num_moved_100 / len(postcodes_new) * 100)
+)
+print('Position moved more than 1000 meters: %d (%.3f%%)' % (
+    num_moved_1000,
+    num_moved_1000 / len(postcodes_new) * 100)
+)
+print('Position moved more than 10000 meters: %d (%.3f%%)' % (
+    num_moved_10000,
+    num_moved_10000 / len(postcodes_new) * 100)
+)
+print('Average distance difference of all updates: %0.2f meters' % (
+    distance_differences / num_moved)
+)

--- a/convert.py
+++ b/convert.py
@@ -2,16 +2,16 @@
 
 import sys
 import glob
-import csv
 
 from csv import DictReader, DictWriter
 from pyproj import Transformer
+from lib.convert import normalize_postcode, check_postcode
 
 ##
 ## CSV Input
 ##
 
-in_filenames = glob.glob('codepo_gb/Data/CSV/*.csv')
+in_filenames = sorted(glob.glob('codepo_gb/Data/CSV/*.csv'))
 
 # 10 columns but we only need the first 4
 in_fieldnames = ['postcode', 'positional_quality_indicator', 'eastings', 'northings']
@@ -29,7 +29,7 @@ transformer = Transformer.from_crs('EPSG:27700', 'EPSG:4326')
 ##
 out_filenames = ['postcode', 'lat', 'lon']
 
-csv_writer = DictWriter(sys.stdout, fieldnames=out_filenames)
+csv_writer = DictWriter(sys.stdout, fieldnames=out_filenames, lineterminator="\n")
 csv_writer.writeheader()
 
 
@@ -42,8 +42,14 @@ for fieldname in in_filenames:
             # Starting Proj version 6 the order of the coordinates changed
             latitude, longitude = transformer.transform(row['eastings'], row['northings'])
 
+            postcode = normalize_postcode(row['postcode'])
+
+            if not check_postcode(postcode):
+                print("invalid postcode '%s'" % postcode, File=sys.stderr)
+                continue
+
             csv_writer.writerow({
-                'postcode': row['postcode'],
+                'postcode': postcode,
                 'lat': '%0.5f' % latitude,
-                'lon': '%0.5f' % longitude 
+                'lon': '%0.5f' % longitude
             })

--- a/lib/convert.py
+++ b/lib/convert.py
@@ -1,0 +1,33 @@
+import re
+import math
+
+# https://en.wikipedia.org/wiki/Postcodes_in_the_United_Kingdom#Validation
+# but changed ' ?' to ' ' because we want to enforce the space
+REGEX_VALID_POSTCODE = '^(([A-Z]{1,2}[0-9][A-Z0-9]?|ASCN|STHL|TDCU|BBND|[BFS]IQQ|PCRN|TKCA) [0-9][A-Z]{2}|BFPO ?[0-9]{1,4}|(KY[0-9]|MSR|VG|AI)[ -]?[0-9]{4}|[A-Z]{2} ?[0-9]{2}|GE ?CX|GIR ?0A{2}|SAN ?TA1)$'
+
+def normalize_postcode(postcode):
+    # multiple space to one
+    postcode = re.sub(r'\s+', ' ', postcode)
+
+    # add space if needed
+    postcode = re.sub(r'(\S)(\d[A-Z][A-Z])$', '\\1 \\2', postcode)
+    return postcode
+
+def check_postcode(postcode):
+    return bool(re.match(REGEX_VALID_POSTCODE, postcode))
+
+# https://janakiev.com/blog/gps-points-distance-python/
+# returns distance in meters
+def haversine(coord1, coord2):
+    R = 6372800  # Earth radius in meters
+    lat1, lon1 = coord1
+    lat2, lon2 = coord2
+
+    phi1, phi2 = math.radians(lat1), math.radians(lat2) 
+    dphi       = math.radians(lat2 - lat1)
+    dlambda    = math.radians(lon2 - lon1)
+
+    a = math.sin(dphi/2)**2 + \
+        math.cos(phi1)*math.cos(phi2)*math.sin(dlambda/2)**2
+
+    return 2*R*math.atan2(math.sqrt(a), math.sqrt(1 - a))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+import sys
+sys.path.insert(0,'.')

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,0 +1,13 @@
+import pytest
+
+from lib.convert import normalize_postcode, check_postcode
+
+def test_normalize_postcode():
+    assert normalize_postcode('E8  1LN') == 'E8 1LN'
+    assert normalize_postcode('E81LN') == 'E8 1LN'
+
+def test_check_postcode():
+    assert check_postcode('N6 5XR') == True
+    assert check_postcode('n6 5xr') == False
+    assert check_postcode('N65XR') == False
+    assert check_postcode('N6') == False


### PR DESCRIPTION
1. sort input filenames, Python's `glob` is unsorted by default
2. make sure postcodes contain a space and fix those who don't
3. validate postcodes against an official regular expression
4. Use \n (Unix style) to terminate lines, Python's CSV writer defaults to \r\n (DOS style)
5. new script `compare.py` to make it easier to spot changes in the output *.csv files

The current 2021-08 rounds coordinates to 5 digits (about 1 meter precision), the previous 2021-05 didn't.

```bash
wget https://downloads.opencagedata.com/public/gb_postcodes.202105.csv.gz
zcat gb_postcodes.202105.csv.gz \
| grep -v '^(' \
| perl -pe's/(\d+\.\d+)\b/sprintf("%.05f", $1)/eg' \
> gb_postcodes.previous.csv

./download.sh
./convert.py > gb_postcodes.csv

./compare.py gb_postcodes.previous.csv gb_postcodes.csv
Read 1717777 postcodes from old file gb_postcodes.previous.csv
Read 1719485 postcodes from new file gb_postcodes.csv
Added: 3674 (0.214%)
Deleted: 1966 (0.114%)
Position moved: 68857 (4.005%)
Position moved more than 100 meters: 10517 (0.612%)
Position moved more than 1000 meters: 553 (0.032%)
Position moved more than 10000 meters: 16 (0.001%)
Average distance difference of all updates: 83.76 meters
```

fixes https://github.com/osm-search/gb-postcode-data/issues/9